### PR TITLE
strip `||` from `@see` line

### DIFF
--- a/gen_vim.lua
+++ b/gen_vim.lua
@@ -111,6 +111,7 @@ for _, file in ipairs(files) do
   for line in io.lines(RUNTIME..'/lua/vim/'..file) do
     local doc = line:match('^%s*(%-%-%-.*)')
     if doc then
+      doc = string.gsub(doc, '^---%s*@see |([^|]+)|(.*)', '--- @see %1%2')
       buf[#buf+1] = doc
     else
       local sig = line:match('^%s*function%s+(vim%..*%(.*%))')


### PR DESCRIPTION
hi, the `||` used in `@see` lines seems to be vim-specific annotation which is not understood by luals, this pr will remove them.

* `--- @see |string.gmatch()|` -> `--- @see string.gmatch()`
* `---@see |vim.list_contains()| for checking values in list-like tables` -> `---@see vim.list_contains() for checking values in list-like tables`